### PR TITLE
deviseのstrong parametersを設定する #4

### DIFF
--- a/bookers2/app/controllers/application_controller.rb
+++ b/bookers2/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:email])
+  end
+  # devise.rbの記述変更により、devise側で追加されるストロングパラメータがnameとpasswordになるので、application_controller.rbではemailを追加する必要がある
+
 end


### PR DESCRIPTION
why
deviseでstrong parametersを利用するため

what
ユーザ登録（sign_up）の際に、メールアドレス（email）のデータ操作が許可されるようにアクションメソッドを指定した