### PR TITLE
ログイン画面のフォーム変更 #6

### DIFF
--- a/bookers2/app/views/devise/sessions/new.html.erb
+++ b/bookers2/app/views/devise/sessions/new.html.erb
@@ -2,9 +2,10 @@
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.label :name %><br />
+    <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
   </div>
+  <!-- emailを送るフォームから、nameを送るフォームに変更する -->
 
   <div class="field">
     <%= f.label :password %><br />

--- a/bookers2/config/initializers/devise.rb
+++ b/bookers2/config/initializers/devise.rb
@@ -46,7 +46,8 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:name]
+  # ログインに使う値をemailからnameに変更
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the


### PR DESCRIPTION
why
名前でログインをできるようにするため

what
1. app/views/users/sessions/new.html.erbファイルの記述を変更 emailを送るフォームから、nameを送るフォームに変更した

2. config/initializers/devise.rbファイルの記述を変更 ログインに使う値をemailからnameに変更した