### PR TITLE
ログアウト機能を実装 #7

### DIFF
--- a/bookers2/app/views/layouts/application.html.erb
+++ b/bookers2/app/views/layouts/application.html.erb
@@ -10,6 +10,18 @@
   </head>
 
   <body>
+    <% if user_signed_in? %>
+      <li>
+        <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
+      </li>
+    <% else %>
+      <li>
+        <%= link_to "新規登録", new_user_registration_path %>
+      </li>
+      <li>
+        <%= link_to "ログイン", new_user_session_path %>
+      </li>
+    <% end %>
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
why
ユーザ登録後、ログイン状態のままになってしまうため

what
ログイン済みの場合、トップページにログアウトのリンクが表示されるようにコードを記述した。
ログインしていない場合、トップページに新規登録とログインのリンクが表示されるようにコードを記述した。