### PR TITLE
ユーザーテーブルの編集 #17

### DIFF
--- a/bookers2/Gemfile
+++ b/bookers2/Gemfile
@@ -62,3 +62,6 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'devise'
+
+gem "refile", require: "refile/rails", github: 'manfe/refile'
+gem "refile-mini_magick"

--- a/bookers2/Gemfile.lock
+++ b/bookers2/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/manfe/refile.git
+  revision: 46b4178654e60bb5846b1423acf6d0740cdecc25
+  specs:
+    refile (0.6.2)
+      mime-types
+      rest-client (~> 2)
+      sinatra (~> 2.0.0.beta2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -80,11 +89,16 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.10.0)
     execjs (2.7.0)
     ffi (1.15.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     io-like (0.3.1)
@@ -101,10 +115,17 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0225)
+    mini_magick (4.11.0)
     mini_mime (1.1.0)
     mini_portile2 (2.5.0)
     minitest (5.14.4)
     msgpack (1.4.2)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    netrc (0.11.0)
     nio4r (2.5.7)
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
@@ -114,6 +135,8 @@ GEM
     puma (3.12.6)
     racc (1.5.2)
     rack (2.2.3)
+    rack-protection (2.0.8.1)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.5)
@@ -144,10 +167,19 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    refile-mini_magick (0.2.0)
+      mini_magick (~> 4.0)
+      refile (~> 0.5)
     regexp_parser (2.1.1)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    ruby2_keywords (0.0.4)
     ruby_dep (1.5.0)
     rubyzip (2.3.0)
     sass (3.7.4)
@@ -164,6 +196,11 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sinatra (2.0.8.1)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.8.1)
+      tilt (~> 2.0)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -186,6 +223,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (3.7.0)
@@ -213,6 +253,8 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.11)
   rails (~> 5.2.5)
+  refile!
+  refile-mini_magick
   sass-rails (~> 5.0)
   selenium-webdriver
   spring

--- a/bookers2/db/migrate/20210416083111_devise_create_users.rb
+++ b/bookers2/db/migrate/20210416083111_devise_create_users.rb
@@ -34,6 +34,8 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
 
       t.string :name
       # 名前でログインできるように、nameカラムを追加
+      t.string :introduction
+      t.string :profile_image_id
       t.timestamps null: false
     end
 

--- a/bookers2/db/schema.rb
+++ b/bookers2/db/schema.rb
@@ -19,6 +19,8 @@ ActiveRecord::Schema.define(version: 2021_04_16_083111) do
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.string "name"
+    t.string "introduction"
+    t.string "profile_image_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
why
ユーザーの画像を投稿に表示させる、ユーザーテーブルにカラムを追加させるため

what
1. 「refile」「refile-mini_magick」をインストールした
2. ユーザーテーブルにintroduction：自己紹介文、profile_image_id：「refile」による画像保存用のカラムを追加した