### PR TITLE
rails c 標準のconsoleのツールであるirbからpryに変更 #64

### DIFF
--- a/bookers2/Gemfile
+++ b/bookers2/Gemfile
@@ -39,6 +39,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry-rails'
 end
 
 group :development do

--- a/bookers2/Gemfile.lock
+++ b/bookers2/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     chronic (0.10.2)
+    coderay (1.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -151,6 +152,11 @@ GEM
     parser (3.0.1.0)
       ast (~> 2.4.1)
     popper_js (1.16.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (3.12.6)
     racc (1.5.2)
@@ -320,6 +326,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  pry-rails
   puma (~> 3.11)
   rails (~> 5.2.5)
   refile!


### PR DESCRIPTION
why
高速にルーティングや、モデルの内容を確認できるようにするため

what
標準のconsoleのツールであるirbからpryに変更